### PR TITLE
Antiantichess Fixes

### DIFF
--- a/client/chess.ts
+++ b/client/chess.ts
@@ -301,8 +301,8 @@ export const VARIANTS: { [name: string]: Variant } = {
             chess960: true, icon: "♔", icon960: "♔",
         }),
             
-    antiantichess: new Variant({
-            name: "anti-antichess", tooltip: () => _("loose at antichess"),
+    anti_antichess: new Variant({
+            name: "anti_antichess", displayName: "anti-antichess", tooltip: () => _("loose at antichess"),
             startFen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
             board: "standard8x8", piece: "standard",
             pieceRoles: ["k", "q", "r", "b", "n", "p"],
@@ -761,7 +761,7 @@ const disabledVariants = [ "gothic", "gothhouse", "embassy" ];
 export const enabledVariants = variants.filter(v => !disabledVariants.includes(v));
 
 const variantGroups: { [ key: string ]: { variants: string[] } } = {
-    standard: { variants: [ "antichess", "losers"] },
+    standard: { variants: [ "antichess", "losers", "anti_antichess"] },
     //sea:      { variants: [ "makruk", "makpong", "cambodian", "sittuyin", "asean" ] },
     //shogi:    { variants: [ "shogi", "minishogi", "kyotoshogi", "dobutsu", "gorogoro", "torishogi" ] },
     //xiangqi:  { variants: [ "xiangqi", "manchu", "janggi", "minixiangqi" ] },

--- a/server/compress.py
+++ b/server/compress.py
@@ -18,7 +18,7 @@ V2C = {
     "racingkings": "F",
     "antichess": "f",
     "losers": "H",
-    "anti-antichess": "V",
+    "anti_antichess": "V",
     "makruk": "m",
     "placement": "p",
     "seirawan": "s",

--- a/server/const.py
+++ b/server/const.py
@@ -47,8 +47,8 @@ VARIANTS = (
     "antichess960",
     "losers",
     "losers960",
-#    "anti-antichess", until its fully tested 
-#    "anti-antichess960" until its fully tested 
+    "anti_antichess",
+    "anti_antichess960"
     # We support to import/store/analyze these variants
     # but don't support to add them to leaderboard page
     # "gothic",
@@ -75,8 +75,8 @@ VARIANT_ICONS = {
     "antichess960": "♔",
     "losers": "♔",
     "losers960": "♔",
-    "anti-antichess": "♔",
-    "anti-antichess960": "♔",
+    "anti_antichess": "♔",
+    "anti_antichess960": "♔",
     "capablanca": "P",
     "capahouse": "&",
     "seirawan": "L",
@@ -121,7 +121,7 @@ VARIANT_960_TO_PGN = {
     "atomic": "Atomic",          # to let lichess import work
     "antichess": "Antichess",          # to let lichess import work    
     "losers": "Losers960",
-    "anti-antichess": "Anti-antichess960",     
+    "anti_antichess": "Anti_antichess960",     
     "seirawan": "Seirawan960",
     # some early game is accidentally saved as 960 in mongodb
     "shogi": "Shogi",

--- a/variants.ini
+++ b/variants.ini
@@ -1,8 +1,4 @@
-[losers]
-startFen = rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
-mustCapture = true
-
 # Lose at anti-chess win at anti-antichess.
-[anti-antichess:giveaway]
+[anti_antichess:giveaway]
 extinctionValue = loss
 stalemateValue = win


### PR DESCRIPTION
Also adding losers in the variants.ini file makes no sense considering that losers isn't even configured in that file and only a single rule is added and also fairy stockfish supports losers chess without any extra configuration in a variants.ini file. losers still works perfectly fine.

This PR is fully tested to support Antiantichess. You can test it here https://lichess-bot-tournaments.herokuapp.com/ . If any bugs in any variant because of this PR, do mention.