### PR TITLE
Fix variant rules

### DIFF
--- a/client/variantsIni.ts
+++ b/client/variantsIni.ts
@@ -16,6 +16,7 @@ extinctionValue = win
 promotionPieceTypes = nbrqk
 commoner = k
 extinctionPieceTypes = *
+extinctionPseudoRoyal = false
 castling = false
 
 # Hybrid of antichess and zh. Antichess is the base variant.

--- a/client/variantsIni.ts
+++ b/client/variantsIni.ts
@@ -3,28 +3,40 @@ export const variantsIni = `
 [anti_antichess:giveaway]
 extinctionValue = loss
 stalemateValue = loss
+castling = false
 
 # Hybrid of antichess and atomic
-[antiatomic:giveaway]
-blastOnCapture = true
+# This might look like what you'd call coffeeatomic, but it isn't.
+[antiatomic:atomic]
+mustCapture = true
+stalemateValue = win
+extinctionValue = win
+promotionPieceTypes = nbrqk
+commoner = k
+extinctionPieceTypes = *
+castling = false
 
 # Hybrid of antichess and zh. Antichess is the base variant.
 [antihouse:giveaway]
 pieceDrops = true
 capturesToHand = true
 pocketSize = 6
+castling = false
 
-# Hybrid of antichess and zh
+# Hybrid of antichess and zh. Zh is th base variant.
 [coffeehouse:crazyhouse]
 mustCapture = true
+castling = false
 
 # Hybrid variant of antichess and king of the hill
 [coffeehill:kingofthehill]
 mustCapture = true
+castling = false
 
 # Hybrid variant of antichess, atomic and king of the hill
 [atomic_giveaway_hill:giveaway]
 blastOnCapture = true
 flagPiece = k
 whiteFlag = d4 e4 d5 e5
-blackFlag = d4 e4 d5 e5`
+blackFlag = d4 e4 d5 e5
+castling = false`

--- a/client/variantsIni.ts
+++ b/client/variantsIni.ts
@@ -26,12 +26,10 @@ castling = false
 # Hybrid of antichess and zh. Zh is th base variant.
 [coffeehouse:crazyhouse]
 mustCapture = true
-castling = false
 
 # Hybrid variant of antichess and king of the hill
 [coffeehill:kingofthehill]
 mustCapture = true
-castling = false
 
 # Hybrid variant of antichess, atomic and king of the hill
 [atomic_giveaway_hill:giveaway]

--- a/client/variantsIni.ts
+++ b/client/variantsIni.ts
@@ -8,6 +8,8 @@ castling = false
 # Hybrid of antichess and atomic
 # This might look like what you'd call coffeeatomic, but it isn't.
 [antiatomic:atomic]
+king = -
+commoner = k
 mustCapture = true
 stalemateValue = win
 extinctionValue = win

--- a/variants.ini
+++ b/variants.ini
@@ -2,24 +2,35 @@
 [anti_antichess:giveaway]
 extinctionValue = loss
 stalemateValue = loss
+castling = false
 
 # Hybrid of antichess and atomic
-[antiatomic:giveaway]
-blastOnCapture = true
+# This might look like what you'd call coffeeatomic, but it isn't.
+[antiatomic:atomic]
+mustCapture = true
+stalemateValue = win
+extinctionValue = win
+promotionPieceTypes = nbrqk
+commoner = k
+extinctionPieceTypes = *
+castling = false
 
 # Hybrid of antichess and zh. Antichess is the base variant.
 [antihouse:giveaway]
 pieceDrops = true
 capturesToHand = true
 pocketSize = 6
+castling = false
 
 # Hybrid of antichess and zh. Zh is th base variant.
 [coffeehouse:crazyhouse]
 mustCapture = true
+castling = false
 
 # Hybrid variant of antichess and king of the hill
 [coffeehill:kingofthehill]
 mustCapture = true
+castling = false
 
 # Hybrid variant of antichess, atomic and king of the hill
 [atomic_giveaway_hill:giveaway]
@@ -27,3 +38,4 @@ blastOnCapture = true
 flagPiece = k
 whiteFlag = d4 e4 d5 e5
 blackFlag = d4 e4 d5 e5
+castling = false

--- a/variants.ini
+++ b/variants.ini
@@ -25,12 +25,10 @@ castling = false
 # Hybrid of antichess and zh. Zh is th base variant.
 [coffeehouse:crazyhouse]
 mustCapture = true
-castling = false
 
 # Hybrid variant of antichess and king of the hill
 [coffeehill:kingofthehill]
 mustCapture = true
-castling = false
 
 # Hybrid variant of antichess, atomic and king of the hill
 [atomic_giveaway_hill:giveaway]

--- a/variants.ini
+++ b/variants.ini
@@ -15,6 +15,7 @@ extinctionValue = win
 promotionPieceTypes = nbrqk
 commoner = k
 extinctionPieceTypes = *
+extinctionPseudoRoyal = false
 castling = false
 
 # Hybrid of antichess and zh. Antichess is the base variant.

--- a/variants.ini
+++ b/variants.ini
@@ -7,6 +7,8 @@ castling = false
 # Hybrid of antichess and atomic
 # This might look like what you'd call coffeeatomic, but it isn't.
 [antiatomic:atomic]
+king = -
+commoner = k
 mustCapture = true
 stalemateValue = win
 extinctionValue = win


### PR DESCRIPTION
- Fixes antiatomic ending rule (should be a draw not a win/loss).
- Disables castling from all variants (as per Fairy sf giveaway is antichess with castling).